### PR TITLE
update codebuild file

### DIFF
--- a/webspec.yml
+++ b/webspec.yml
@@ -37,7 +37,6 @@ phases:
       - ./hugo -D
       - HTML_PROOFER="$(gem contents html-proofer | grep '/bin/')"
       - echo running html-proofer
-      - echo lang is $LANG
       - $HTML_PROOFER  ./public --check-html --empty-alt-ignore --allow-hash-href
       # fail if proofer has issues... if you want to deploy anyway, move these back to post_build
       - echo Deploy website static content to S3 Bucket

--- a/webspec.yml
+++ b/webspec.yml
@@ -4,31 +4,42 @@ phases:
   install:
     runtime-versions:
       docker: 18
-      dotnet: 2.2
       python: 3.7
-      ruby: 2.6
+      ruby: 2.7
   pre_build:
     commands:
+      - export LC_ALL="en_US.UTF-8"
+      - locale-gen en_US en_US.UTF-8
+      - dpkg-reconfigure locales
       - COMMIT_HASH=$(echo $CODEBUILD_RESOLVED_SOURCE_VERSION | cut -c 1-7)
       - IMAGE_TAG=${COMMIT_HASH:=latest}
-      - echo Initializing Git Repo
-      - git init
-      - git remote add origin $FULL_REPO_URL
-      - git fetch
-      - git checkout -f "$CODEBUILD_RESOLVED_SOURCE_VERSION"
-      - git submodule init
-      - git submodule update --recursive
+      - |
+        if [ ! -d ".git"]; then
+          echo Initializing Git Repo
+          git init
+          git remote add origin $FULL_REPO_URL
+          git fetch
+          git checkout -f "$CODEBUILD_RESOLVED_SOURCE_VERSION"
+        fi
+#      - git submodule init
+#      - git submodule update --recursive
       - echo Install Hugo
       # Use known tested version of Hugo
-      - wget -q https://github.com/gohugoio/hugo/releases/download/v0.68.1/hugo_0.68.1_Linux-64bit.tar.gz
+      - curl -s https://api.github.com/repos/gohugoio/hugo/releases/latest | grep "download_url.*Linux-64bit.tar.gz" | grep -v "extended" | cut -d '"' -f 4 | wget -qi -
       - HUGO_TAR="$(find . -name "*Linux-64bit.tar.gz")"
       - tar -xzf $HUGO_TAR
       - chmod +x hugo
+      - gem install html-proofer
 
   build:
     commands:
       - echo Build website
       - ./hugo -D
+      - HTML_PROOFER="$(gem contents html-proofer | grep '/bin/')"
+      - echo running html-proofer
+      - echo lang is $LANG
+      - $HTML_PROOFER  ./public --check-html --empty-alt-ignore --allow-hash-href
+      # fail if proofer has issues... if you want to deploy anyway, move these back to post_build
       - echo Deploy website static content to S3 Bucket
       - aws s3 cp public/ s3://${WEB_SITE_BUCKET}/ --recursive
       - aws cloudfront create-invalidation --distribution-id ${CLOUDFRONT_DISTRO_ID} --paths /\*


### PR DESCRIPTION
This commit updates `webspec.yml` to 
1.  Use latest release of hugo
2.  Install [htmlproofer](https://github.com/gjtorikian/html-proofer) and use it to validate the HTML generated by hugo

If the validation detects any issues, it will now fail the build and not deploy out.  As of this PR there are four external links that are not validating, I would be happy to chase those down and add the corrections to this PR if you want.

Alternatively we could ignore any errors from htmlproofer and deploy the artifacts by moving the deployment steps back to `post_build` as that stage is run whether the `build` stage succeeds or not.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
